### PR TITLE
new version of php oauth2 server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "twig/twig": "1.14.2",
         "twig/extensions": "1.0.0",
         "doctrine/orm": "2.4.0",
-        "bshaffer/oauth2-server-php": "1.2"
+        "bshaffer/oauth2-server-php": "v1.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
You need the new version of oauth or else when requestion a token will give you the following error
{"error":"SQLSTATE[42S22]: Column not found: 1054 Unknown column 'type' in 'where clause'","code":"42S22"}
Check http://bshaffer.github.io/oauth2-server-php-docs/ for version 1.3
