### PR TITLE
Added "branch-alias" for composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,10 @@
     },
     "config": {
         "bin-dir": "bin"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.5-dev"
+        }
     }
 }


### PR DESCRIPTION
Added "branch-alias" property in order to allow installation of development versions while keeping semver basis.
