### PR TITLE
Less restrictive requirement constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Rogério Alencar Lino Filho", 
+            "name": "Rogério Alencar Lino Filho",
             "email": "rogeriolino@gmail.com",
             "homepage": "http://rogeriolino.com",
             "role": "Developer"
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php": ">=5.4",
-        "slim/slim": "2.6.2",
-        "slim/views": "0.1.3",
-        "twig/twig": "1.18.1",
-        "twig/extensions": "1.2.0",
-        "doctrine/orm": "2.5.0",
-        "bshaffer/oauth2-server-php": "1.7.0"
+        "slim/slim": "~2.6",
+        "slim/views": "~0.1",
+        "twig/twig": "~1.18",
+        "twig/extensions": "~1.2",
+        "doctrine/orm": "~2.5",
+        "bshaffer/oauth2-server-php": "~1.7"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Make use of tilde operator in order to allow composer resolve higher patch and minor versions of each dependency.