### PR TITLE
Senhas normais passam na frente de prioridade #281

### DIFF
--- a/src/Novosga/Service/FilaService.php
+++ b/src/Novosga/Service/FilaService.php
@@ -17,14 +17,14 @@ class FilaService extends ModelService
 {
     // default queue ordering
     public static $ordering = [
-        // wait time
-        [
-            'exp'   => '((p.peso + 1) * (CURRENT_TIMESTAMP() - e.dataChegada))',
-            'order' => 'DESC',
-        ],
         // priority
         [
             'exp'   => 'p.peso',
+            'order' => 'DESC',
+        ],
+        // wait time
+        [
+            'exp'   => '((p.peso + 1) * (CURRENT_TIMESTAMP() - e.dataChegada))',
             'order' => 'DESC',
         ],
         // ticket number


### PR DESCRIPTION
Fixes #281

A identificação da ordem deve ser da seguinte forma:
• Inicialmente pelo peso da prioridade;
• Em seguida verificar o tempo de espera;
• E por fim o número da senha.