### PR TITLE
Classe BCryptPasswordEncoder não existe

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
+use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
@@ -295,7 +295,7 @@ class InstallCommand extends UpdateCommand
         $user->setAdmin(true);
         $user->setAtivo(true);
 
-        $encoder = new BCryptPasswordEncoder(12);
+        $encoder = new NativePasswordEncoder(null, null, 12);
         $encoded = $encoder->encodePassword($password, $user->getSalt());
 
         $user->setSenha($encoded);


### PR DESCRIPTION
No [Symfony 4.4](https://github.com/symfony/security-core/blob/4.4/Encoder/BCryptPasswordEncoder.php?rgh-link-date=2023-07-07T14%3A06%3A56Z), já existe um alerta informando sobre a descontinuação dessa classe.

O código existente não é compatível com a [versão 5.2 do Symfony](https://github.com/novosga/novosga/blob/0512510f91069b80bd07b944f6c8420fbecd3060/composer.json#L58). O novo código corrige esse problema.

Mais sobre o problema: https://github.com/novosga/novosga/issues/370#issuecomment-1625442209