### PR TITLE
Resolve CORS preflight request doesn't pass

### DIFF
--- a/public/api/index.php
+++ b/public/api/index.php
@@ -284,11 +284,25 @@ foreach ($config->routes() as $pattern => $callable) {
 
 // response
 
+// Handle CORS preflight requests
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    // CORS headers for preflight requests
+    header("Access-Control-Allow-Origin: *");
+    header("Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE");
+    header("Access-Control-Allow-Credentials: true");
+    header("Access-Control-Max-Age: 1000");
+    header("Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization");
+    
+    // Send the proper response
+    http_response_code(200);
+    exit();
+}
+
+// CORS headers for actual requests
 header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE");
-header('Access-Control-Allow-Credentials: true');
-header("Access-Control-Max-Age: 1000");
-header("Access-Control-Allow-Headers: origin, x-requested-with, content-type");
+header("Access-Control-Allow-Credentials: true");
+header("Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization");
 
 $app->contentType('application/json');
 $app->run();

--- a/public/api/index.php
+++ b/public/api/index.php
@@ -302,6 +302,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Methods: POST, GET, OPTIONS, PUT, DELETE");
 header("Access-Control-Allow-Credentials: true");
+header("Access-Control-Max-Age: 1000");
 header("Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Authorization");
 
 $app->contentType('application/json');


### PR DESCRIPTION
About this error:
```
Access to XMLHttpRequest at 'http://domainx:port/api/distribui' from origin 'http://domainy:port'
has been blocked by CORS policy: Response to preflight request doesn't pass access control
check: It does not have HTTP ok status.
```

The error above indicates that the preflight request (an HTTP OPTIONS request) made by the browser doesn't receive a valid response with an HTTP 200 OK status. This happens when the server doesn't handle the OPTIONS request correctly or when there's an issue with the CORS headers.

By implementing these changes, the server will properly handle CORS preflight requests, and the CORS errors will be resolved.