### PR TITLE
fix: Renaming MERCURE_PUBLIC_URL to MERCURE_PUBLISH_URL

### DIFF
--- a/.env
+++ b/.env
@@ -31,9 +31,8 @@ CORS_ALLOW_ORIGIN=^https?://localhost(:[0-9]+)?$
 
 ###> symfony/mercure-bundle ###
 # See https://symfony.com/doc/current/mercure.html#configuration
-MERCURE_PUBLIC_URL=http://mercure/.well-known/mercure
+MERCURE_PUBLISH_URL=http://mercure/.well-known/mercure
+MERCURE_CONSUMER_URL=/.well-known/mercure
 # The default token is signed with the secret key: !ChangeMe!
 MERCURE_JWT_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOltdfX0.Oo0yg7y4yMa1vr_bziltxuTCqb8JVHKxp-f_FwwOim0
-# Novo SGA custom var
-MERCURE_CONSUMER_URL=/.well-known/mercure
 ###< symfony/mercure-bundle ###

--- a/config/packages/mercure.yaml
+++ b/config/packages/mercure.yaml
@@ -1,5 +1,8 @@
+parameters:
+    mercure_publish_url: '%env(MERCURE_PUBLISH_URL)%'
+
 mercure:
     hubs:
         default:
-            url: '%env(MERCURE_PUBLIC_URL)%'
+            url: '%env(string:default:mercure_publish_url:MERCURE_PUBLIC_URL)%'
             jwt: '%env(MERCURE_JWT_TOKEN)%'


### PR DESCRIPTION
A variável `MERCURE_PUBLIC_URL` foi definida de forma equivocada quando a versão do mercure-bundle foi atualizada. Para a configuração ficar mais concisa, agora as variáveis são:

- **MERCURE_PUBLISH_URL**: URL utilizada para publicar mensagem (via PHP/servidor)
- **MERCURE_CONSUMER_URL**: URL utilizada para consumir mensagem (via Javascript/navegador)

E para evitar quebra de compatibilidade, a variável `MERCURE_PUBLIC_URL` continua funcionando caso a variável `MERCURE_PUBLISH_URL` não esteja definida.