### PR TITLE
fix: Avoid to update sessionId from OAuth2 token

### DIFF
--- a/src/EventSubscriber/UserSessionIdSubscriber.php
+++ b/src/EventSubscriber/UserSessionIdSubscriber.php
@@ -15,6 +15,7 @@ namespace App\EventSubscriber;
 
 use App\Entity\Usuario;
 use Doctrine\ORM\EntityManagerInterface;
+use League\Bundle\OAuth2ServerBundle\Security\Authentication\Token\OAuth2Token;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
@@ -34,6 +35,11 @@ class UserSessionIdSubscriber implements EventSubscriberInterface
 
     public function onLoginSuccess(LoginSuccessEvent $event): void
     {
+        if ($event->getAuthenticatedToken() instanceof OAuth2Token) {
+            // do not set session id for OAuth2 tokens
+            return;
+        }
+
         /** @var Usuario */
         $user = $event->getUser();
         $sessionId = $this->requestStack->getSession()->getId();


### PR DESCRIPTION
The `UserSessionIdSubscriber::onLoginSuccess` event subscriber is being called when requesting any protected endpoint using a valid access_token. Since there is no session, it overrides the current session_id from authenticated user, making it be disconnected (redirects to login page).

Fixes #428