### PR TITLE
fix: Adding support for servico.peso ordering

### DIFF
--- a/src/Form/Settings/QueueOrderingFormType.php
+++ b/src/Form/Settings/QueueOrderingFormType.php
@@ -30,17 +30,18 @@ class QueueOrderingFormType extends AbstractType
                     'Data de agendamento' => 'dataAgendamento',
                     'Data de chegada' => 'dataChegada',
                     'Peso prioridade' => 'prioridade',
+                    'Peso serviço' => 'servico',
                     'Peso serviço usuário' => 'servicoUsuario',
                     'Peso serviço unidade' => 'servicoUnidade',
                     'Balanceamento prioridade vs data chegada' => 'balanceamento',
-                ]
+                ],
             ])
             ->add('order', ChoiceType::class, [
                 'label'   => 'label.order',
                 'choices' => [
                     'Asc'  => 'ASC',
                     'Desc' => 'DESC',
-                ]
+                ],
             ])
         ;
     }

--- a/src/Service/DefaultQueueOrderingService.php
+++ b/src/Service/DefaultQueueOrderingService.php
@@ -52,6 +52,10 @@ class DefaultQueueOrderingService implements QueueOrderingServiceInterface
                         $queryBuilder->addOrderBy('prioridade.peso', $sort);
                     }
                     break;
+                case 'servico':
+                    // peso servico
+                    $queryBuilder->addOrderBy('servico.peso', $sort);
+                    break;
                 case 'servicoUsuario':
                     if ($usuario) {
                         // peso servico x usuario


### PR DESCRIPTION
No formulário de configuração da ordem da fila está faltando a opção de ordenar pelo peso do serviço. Esse PR adiciona essa nova opção ao formulário e ao serviço de ordenação da fila.