### PR TITLE
feat: Adding @type field to mercure events

### DIFF
--- a/src/Dto/MercureEvent.php
+++ b/src/Dto/MercureEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the NovoSGA project.
+ *
+ * (c) Rogerio Lino <rogeriolino@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Dto;
+
+use JsonSerializable;
+
+/**
+ * MercureEvent
+ *
+ * @author Rogerio Lino <rogeriolino@gmail.com>
+ */
+final class MercureEvent implements JsonSerializable
+{
+    /** @param array<string,mixed> $payload */
+    public function __construct(
+        public readonly string $type,
+        public readonly array $payload = [],
+    ) {
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return array_merge($this->payload, [
+            '@type' => $this->type,
+        ]);
+    }
+}

--- a/src/Service/MercureService.php
+++ b/src/Service/MercureService.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace App\Service;
 
+use App\Dto\MercureEvent;
 use Novosga\Entity\AtendimentoInterface;
 use Novosga\Entity\UnidadeInterface;
 use Novosga\Entity\UsuarioInterface;
@@ -39,17 +40,19 @@ class MercureService
         if ($unidade !== null) {
             $this->publish(
                 [ "/unidades/{$unidade->getId()}/fila" ],
-                [ 'id' => $unidade->getId() ]
+                'queue.unity',
+                [ 'id' => $unidade->getId() ],
             );
         }
 
-        $this->publish([ "/fila" ], []);
+        $this->publish([ "/fila" ], 'queue.global', []);
     }
 
     public function notificaFilaUsuario(UsuarioInterface $usuario): void
     {
         $this->publish(
             [ "/usuarios/{$usuario->getId()}/fila" ],
+            'queue.user',
             [ 'id' => $usuario->getId() ],
         );
     }
@@ -61,6 +64,7 @@ class MercureService
                 '/paineis',
                 "/unidades/{$atendimento->getUnidade()->getId()}/painel",
             ],
+            'panel.ticket',
             [
                 'id' => $atendimento->getId(),
             ],
@@ -78,17 +82,18 @@ class MercureService
             $topics[] = "/usuarios/{$usuario->getId()}/fila";
         }
 
-        $this->publish($topics, [ 'id' => $atendimento->getId() ]);
+        $this->publish($topics, 'ticket', [ 'id' => $atendimento->getId() ]);
     }
 
     /**
      * @param string[] $topics
-     * @param array<string,mixed> $params
+     * @param array<string,mixed> $payload
      */
-    private function publish(array $topics, array $params): void
+    private function publish(array $topics, string $type, array $payload): void
     {
         try {
-            $this->hub->publish(new Update($topics, json_encode($params)));
+            $event = new MercureEvent($type, $payload);
+            $this->hub->publish(new Update($topics, json_encode($event)));
         } catch (RuntimeException $ex) {
             $this->logger->error($ex->getMessage());
         }

--- a/tests/Service/MercureServiceTest.php
+++ b/tests/Service/MercureServiceTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the NovoSGA project.
+ *
+ * (c) Rogerio Lino <rogeriolino@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Service;
+
+use App\Entity\Atendimento;
+use App\Entity\Unidade;
+use App\Entity\Usuario;
+use App\Service\MercureService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+
+/**
+ * MercureServiceTest
+ *
+ * @author Rogerio Lino <rogeriolino@gmail.com>
+ */
+class MercureServiceTest extends TestCase
+{
+    private HubInterface&MockObject $hub;
+    private LoggerInterface&MockObject $logger;
+    private MercureService $service;
+
+    protected function setUp(): void
+    {
+        $this->hub = $this->createMock(HubInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->service = new MercureService($this->hub, $this->logger);
+    }
+
+    public function testNotificaFilaUnidade(): void
+    {
+        $unidade = (new Unidade())->setId(123);
+
+        $this->hub
+            ->expects($this->exactly(2))
+            ->method('publish')
+            ->with($this->callback(function (Update $update) {
+                $data = json_decode($update->getData(), true);
+                $topics = $update->getTopics();
+
+                if (in_array('/unidades/123/fila', $topics)) {
+                    $this->assertArrayHasKey('@type', $data);
+                    $this->assertEquals('queue.unity', $data['@type']);
+                    $this->assertArrayHasKey('id', $data);
+                    $this->assertEquals(123, $data['id']);
+                }
+                if (in_array('/fila', $topics)) {
+                    $this->assertArrayHasKey('@type', $data);
+                    $this->assertEquals('queue.global', $data['@type']);
+                }
+
+                return true;
+            }));
+
+        $this->service->notificaFilaUnidade($unidade);
+    }
+
+    public function testNotificaFilaUsuario(): void
+    {
+        $usuario = (new Usuario())->setId(456);
+
+        $this->hub
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function (Update $update) {
+                $data = json_decode($update->getData(), true);
+                $topics = $update->getTopics();
+
+                $this->assertContains('/usuarios/456/fila', $topics);
+                $this->assertArrayHasKey('@type', $data);
+                $this->assertEquals('queue.user', $data['@type']);
+                $this->assertArrayHasKey('id', $data);
+                $this->assertEquals(456, $data['id']);
+
+                return true;
+            }));
+
+        $this->service->notificaFilaUsuario($usuario);
+    }
+
+    public function testNotificaPainel(): void
+    {
+        $unidade = (new Unidade())->setId(123);
+        $atendimento = (new Atendimento())
+            ->setId(789)
+            ->setUnidade($unidade);
+
+        $this->hub
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function (Update $update) {
+                $data = json_decode($update->getData(), true);
+                $topics = $update->getTopics();
+
+                $this->assertContains('/paineis', $topics);
+                $this->assertContains('/unidades/123/painel', $topics);
+                $this->assertArrayHasKey('@type', $data);
+                $this->assertEquals('panel.ticket', $data['@type']);
+                $this->assertArrayHasKey('id', $data);
+                $this->assertEquals(789, $data['id']);
+
+                return true;
+            }));
+
+        $this->service->notificaPainel($atendimento);
+    }
+
+    public function testNotificaAtendimento(): void
+    {
+        $unidade = (new Unidade())->setId(123);
+        $atendimento = (new Atendimento())
+            ->setId(999)
+            ->setUnidade($unidade);
+
+        $this->hub
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function (Update $update) {
+                $data = json_decode($update->getData(), true);
+                $topics = $update->getTopics();
+
+                $this->assertContains('/atendimentos/999', $topics);
+                $this->assertContains('/unidades/123/fila', $topics);
+                $this->assertArrayHasKey('@type', $data);
+                $this->assertEquals('ticket', $data['@type']);
+                $this->assertArrayHasKey('id', $data);
+                $this->assertEquals(999, $data['id']);
+
+                return true;
+            }));
+
+        $this->service->notificaAtendimento($atendimento);
+    }
+
+    public function testNotificaAtendimentoWithUser(): void
+    {
+        $unidade = (new Unidade())->setId(123);
+        $atendimento = (new Atendimento())
+            ->setId(999)
+            ->setUnidade($unidade);
+        $usuario = (new Usuario())->setId(456);
+
+        $this->hub
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function (Update $update) {
+                $data = json_decode($update->getData(), true);
+                $topics = $update->getTopics();
+
+                $this->assertContains('/atendimentos/999', $topics);
+                $this->assertContains('/unidades/123/fila', $topics);
+                $this->assertContains('/usuarios/456/fila', $topics);
+                $this->assertArrayHasKey('@type', $data);
+                $this->assertEquals('ticket', $data['@type']);
+                $this->assertArrayHasKey('id', $data);
+                $this->assertEquals(999, $data['id']);
+
+                return true;
+            }));
+
+        $this->service->notificaAtendimento($atendimento, $usuario);
+    }
+
+    public function testNotificaFilaUnidadeWithNullUnidade(): void
+    {
+        $this->hub
+        ->expects($this->once())
+            ->method('publish')
+            ->with($this->callback(function (Update $update) {
+                $data = json_decode($update->getData(), true);
+                $topics = $update->getTopics();
+
+                $this->assertContains('/fila', $topics);
+                $this->assertArrayHasKey('@type', $data);
+                $this->assertEquals('queue.global', $data['@type']);
+
+                return true;
+            }));
+
+        $this->service->notificaFilaUnidade(null);
+    }
+}


### PR DESCRIPTION
This pull request refactors the way events are published to Mercure by introducing a dedicated `MercureEvent` DTO to standardize event payloads, and updates the `MercureService` to use explicit event types. It also adds comprehensive tests for the service to ensure correct event formatting and topic assignment.

**Mercure event structure and service refactor:**

* Introduced a new `MercureEvent` DTO (`src/Dto/MercureEvent.php`) to encapsulate event type and payload, ensuring all events have a consistent structure with an `@type` field.
* Refactored the `MercureService` to use the new DTO, updating the `publish` method to accept an explicit event type and payload, and updating all notification methods to specify event types such as `'queue.unity'`, `'queue.global'`, `'queue.user'`, `'panel.ticket'`, and `'ticket'`. [[1]](diffhunk://#diff-02942a0cadded7d82987a49c54f1303336dd07055f5afb5acf0cb433c117fdebR16) [[2]](diffhunk://#diff-02942a0cadded7d82987a49c54f1303336dd07055f5afb5acf0cb433c117fdebL42-R55) [[3]](diffhunk://#diff-02942a0cadded7d82987a49c54f1303336dd07055f5afb5acf0cb433c117fdebR67) [[4]](diffhunk://#diff-02942a0cadded7d82987a49c54f1303336dd07055f5afb5acf0cb433c117fdebL81-R96)

**Testing improvements:**

* Added a new test suite (`tests/Service/MercureServiceTest.php`) that thoroughly tests all notification methods in `MercureService`, verifying that published events have the correct topics and payload structure, including the new `@type` field.