### PR TITLE
fix: installer priority color

### DIFF
--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -343,6 +343,7 @@ class InstallCommand extends UpdateCommand
         $prioridade->setNome($name);
         $prioridade->setDescricao($description);
         $prioridade->setPeso($weight);
+        $prioridade->setCor($weight === 0 ? '#0000FF' : '#FF0000');
         $prioridade->setAtivo(true);
 
         return $prioridade;


### PR DESCRIPTION
Setting a default color for priorities when running the install command.