### PR TITLE
feat: add changeTicketType behavior setting (#460)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2016,12 +2016,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/novosga/attendance-bundle.git",
-                "reference": "331eff5a0a0e1888ce5324038dd0f310b27f9458"
+                "reference": "e2cead5d66efb16c26740e3b7b926ce2425c8a97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/novosga/attendance-bundle/zipball/331eff5a0a0e1888ce5324038dd0f310b27f9458",
-                "reference": "331eff5a0a0e1888ce5324038dd0f310b27f9458",
+                "url": "https://api.github.com/repos/novosga/attendance-bundle/zipball/e2cead5d66efb16c26740e3b7b926ce2425c8a97",
+                "reference": "e2cead5d66efb16c26740e3b7b926ce2425c8a97",
                 "shasum": ""
             },
             "require": {
@@ -2057,7 +2057,7 @@
                 "issues": "https://github.com/novosga/attendance-bundle/issues",
                 "source": "https://github.com/novosga/attendance-bundle/tree/v2.3"
             },
-            "time": "2026-03-20T15:23:56+00:00"
+            "time": "2026-03-23T13:06:43+00:00"
         },
         {
             "name": "novosga/core",
@@ -2065,12 +2065,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/novosga/core.git",
-                "reference": "c1e4148f3df3ead4ebab5c57e34bd0d391a44828"
+                "reference": "6a8aa0bc3469a9a0b035696a2de0fdc3802a5301"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/novosga/core/zipball/c1e4148f3df3ead4ebab5c57e34bd0d391a44828",
-                "reference": "c1e4148f3df3ead4ebab5c57e34bd0d391a44828",
+                "url": "https://api.github.com/repos/novosga/core/zipball/6a8aa0bc3469a9a0b035696a2de0fdc3802a5301",
+                "reference": "6a8aa0bc3469a9a0b035696a2de0fdc3802a5301",
                 "shasum": ""
             },
             "require": {
@@ -2107,7 +2107,7 @@
                 "issues": "https://github.com/novosga/core/issues",
                 "source": "https://github.com/novosga/core/tree/v2.3"
             },
-            "time": "2026-03-20T14:33:24+00:00"
+            "time": "2026-03-23T13:05:10+00:00"
         },
         {
             "name": "novosga/customers-bundle",
@@ -2318,12 +2318,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/novosga/settings-bundle.git",
-                "reference": "52f7e6e3c4211c4d69c660b971f82d69992ed1c4"
+                "reference": "5b693cf7152d19d826c196f82ca08a00d98a6c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/novosga/settings-bundle/zipball/52f7e6e3c4211c4d69c660b971f82d69992ed1c4",
-                "reference": "52f7e6e3c4211c4d69c660b971f82d69992ed1c4",
+                "url": "https://api.github.com/repos/novosga/settings-bundle/zipball/5b693cf7152d19d826c196f82ca08a00d98a6c77",
+                "reference": "5b693cf7152d19d826c196f82ca08a00d98a6c77",
                 "shasum": ""
             },
             "require": {
@@ -2359,7 +2359,7 @@
                 "issues": "https://github.com/novosga/settings-bundle/issues",
                 "source": "https://github.com/novosga/settings-bundle/tree/v2.3"
             },
-            "time": "2026-03-21T14:40:02+00:00"
+            "time": "2026-03-23T13:06:47+00:00"
         },
         {
             "name": "novosga/triage-bundle",

--- a/src/Form/Settings/BehaviorSettingsFormType.php
+++ b/src/Form/Settings/BehaviorSettingsFormType.php
@@ -66,6 +66,11 @@ class BehaviorSettingsFormType extends AbstractType
                     new NotNull(),
                 ],
             ])
+            ->add('changeTicketType', CheckboxType::class, [
+                'label' => 'label.change_ticket_type',
+                'required' => false,
+                'constraints' => [new NotNull()],
+            ])
         ;
     }
 

--- a/src/Service/ApplicationSettingsService.php
+++ b/src/Service/ApplicationSettingsService.php
@@ -101,6 +101,7 @@ class ApplicationSettingsService implements ApplicationSettingsServiceInterface
         return new UserBehaviorSettings(
             callTicketByService: $value['callTicketByService'] ?? $global?->callTicketByService,
             callTicketOutOfOrder: $value['callTicketOutOfOrder'] ?? $global?->callTicketOutOfOrder,
+            changeTicketType: $value['changeTicketType'] ?? $global?->changeTicketType,
         );
     }
 
@@ -113,6 +114,7 @@ class ApplicationSettingsService implements ApplicationSettingsServiceInterface
             [
                 'callTicketByService' => $settings->callTicketByService,
                 'callTicketOutOfOrder' => $settings->callTicketOutOfOrder,
+                'changeTicketType' => $settings->changeTicketType,
             ],
         );
     }

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -103,6 +103,7 @@
                             <div class="col">
                                 {{ form_row(behaviorForm.callTicketByService) }}
                                 {{ form_row(behaviorForm.callTicketOutOfOrder) }}
+                                {{ form_row(behaviorForm.changeTicketType) }}
                             </div>
                         </div>
                     </div>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -110,6 +110,10 @@
                 <source>label.call_ticket_out_of_order</source>
                 <target>Permitir chamar atendimento fora de ordem</target>
             </trans-unit>
+            <trans-unit id="label.change_ticket_type">
+                <source>label.change_ticket_type</source>
+                <target>Change ticket type</target>
+            </trans-unit>
             <trans-unit id="label.url">
                 <source>label.url</source>
                 <target>URL</target>

--- a/translations/messages.en_US.xlf
+++ b/translations/messages.en_US.xlf
@@ -110,6 +110,10 @@
                 <source>label.call_ticket_out_of_order</source>
                 <target>Permitir chamar atendimento fora de ordem</target>
             </trans-unit>
+            <trans-unit id="label.change_ticket_type">
+                <source>label.change_ticket_type</source>
+                <target>Change ticket type</target>
+            </trans-unit>
             <trans-unit id="label.url">
                 <source>label.url</source>
                 <target>URL</target>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -110,6 +110,10 @@
                 <source>label.call_ticket_out_of_order</source>
                 <target>Permitir chamar atendimento fora de ordem</target>
             </trans-unit>
+            <trans-unit id="label.change_ticket_type">
+                <source>label.change_ticket_type</source>
+                <target>Cambiar tipo de atención</target>
+            </trans-unit>
             <trans-unit id="label.url">
                 <source>label.url</source>
                 <target>URL</target>

--- a/translations/messages.es_AR.xlf
+++ b/translations/messages.es_AR.xlf
@@ -110,6 +110,10 @@
                 <source>label.call_ticket_out_of_order</source>
                 <target>Permitir chamar atendimento fora de ordem</target>
             </trans-unit>
+            <trans-unit id="label.change_ticket_type">
+                <source>label.change_ticket_type</source>
+                <target>Cambiar tipo de atención</target>
+            </trans-unit>
             <trans-unit id="label.url">
                 <source>label.url</source>
                 <target>URL</target>

--- a/translations/messages.pt_BR.xlf
+++ b/translations/messages.pt_BR.xlf
@@ -110,6 +110,10 @@
                 <source>label.call_ticket_out_of_order</source>
                 <target>Permitir chamar atendimento fora de ordem</target>
             </trans-unit>
+            <trans-unit id="label.change_ticket_type">
+                <source>label.change_ticket_type</source>
+                <target>Alterar tipo de atendimento</target>
+            </trans-unit>
             <trans-unit id="label.url">
                 <source>label.url</source>
                 <target>URL</target>

--- a/translations/messages.pt_PT.xlf
+++ b/translations/messages.pt_PT.xlf
@@ -110,6 +110,10 @@
                 <source>label.call_ticket_out_of_order</source>
                 <target>Permitir chamar atendimento fora de ordem</target>
             </trans-unit>
+            <trans-unit id="label.change_ticket_type">
+                <source>label.change_ticket_type</source>
+                <target>Alterar tipo de atendimento</target>
+            </trans-unit>
             <trans-unit id="label.url">
                 <source>label.url</source>
                 <target>URL</target>


### PR DESCRIPTION
## Summary

Implements the `changeTicketType` behavior flag requested in novosga/novosga#460, following the same pattern established by #452.

- Adds `changeTicketType` checkbox to the global behavior admin form
- Wires serialization in `ApplicationSettingsService`
- Adds `label.change_ticket_type` to all 6 locale translation files (`en`, `en_US`, `es`, `es_AR`, `pt_BR`, `pt_PT`)

## Test plan

- [x] Set `changeTicketType = false` globally → attendance type selector is disabled, `setLocal()` ignores submitted type
- [x] Set global `true`, user override `false` → only that user is restricted
- [x] User override `null` → inherits global setting
- [x] Existing installs with no stored value → default `true` keeps current behavior

Closes novosga/novosga#460

🤖 Generated with [Claude Code](https://claude.com/claude-code)