### PR TITLE
feat: Distrubui senha agendada via API

### DIFF
--- a/src/Controller/Api/TriagemController.php
+++ b/src/Controller/Api/TriagemController.php
@@ -19,6 +19,7 @@ use App\Entity\Atendimento;
 use App\Service\AtendimentoService;
 use Exception;
 use App\Entity\Usuario;
+use Novosga\Repository\AgendamentoRepositoryInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\HttpFoundation\Request;
@@ -58,6 +59,7 @@ class TriagemController extends ApiControllerBase
         Request $request,
         #[MapRequestPayload] NovaSenha $novaSenha,
         AtendimentoService $service,
+        AgendamentoRepositoryInterface $agendamentoRepository,
         LoggerInterface $logger
     ): Response {
         try {
@@ -71,8 +73,21 @@ class TriagemController extends ApiControllerBase
             $servico = (int) $novaSenha->servico;
             $prioridade = (int) $novaSenha->prioridade;
             $cliente = $novaSenha->cliente;
+            $agendamento = null;
 
-            $response = $service->distribuiSenha($unidade, $usuario, $servico, $prioridade, $cliente);
+            if ($novaSenha->agendamento) {
+                $agendamento = $agendamentoRepository->find($novaSenha->agendamento);
+            }
+
+            $response = $service->distribuiSenha(
+                $unidade,
+                $usuario,
+                $servico,
+                $prioridade,
+                $cliente,
+                $agendamento,
+            );
+
             $status = 201;
         } catch (Exception $ex) {
             $response = [

--- a/src/Dto/NovaSenha.php
+++ b/src/Dto/NovaSenha.php
@@ -36,6 +36,8 @@ final readonly class NovaSenha
         public ?int $servico = null,
         public ?Cliente $cliente = null,
         public mixed $metadata = null,
+        #[Range(min: 1)]
+        public ?int $agendamento = null,
     ) {
     }
 }

--- a/src/Service/AtendimentoService.php
+++ b/src/Service/AtendimentoService.php
@@ -458,6 +458,15 @@ class AtendimentoService implements AtendimentoServiceInterface
             }
         }
 
+        if ($agendamento) {
+            if ($agendamento->getUnidade()?->getId() !== $unidade->getId()) {
+                throw new Exception($this->translator->trans('error.schedule.invalid_unity'));
+            }
+            if ($agendamento->getServico()?->getId() !== $servico->getId()) {
+                throw new Exception($this->translator->trans('error.schedule.invalid_service'));
+            }
+        }
+
         $su = $this->checkServicoUnidade($unidade, $servico);
 
         if (

--- a/tests/Controller/Api/TriagemControllerTest.php
+++ b/tests/Controller/Api/TriagemControllerTest.php
@@ -269,6 +269,133 @@ class TriagemControllerTest extends WebTestCase
         $this->assertSame($result['senha']['sigla'], $servicoUnidade->getSigla());
         $this->assertSame($result['servico']['id'], $servico->getId());
         $this->assertSame($result['prioridade']['id'], $prioridade->getId());
+        $this->assertNull($result['dataAgendamento']);
+    }
+
+    public function testDistribuiSenhaWithInvalidAgendamentoId(): void
+    {
+        $client = static::getClient();
+        $accessToken = TestHelper::generateJwtToken(static::getContainer());
+        $unidade = TestHelper::createUnidade($this->em);
+        $servico = TestHelper::createServico($this->em);
+        $prioridade = TestHelper::createPrioridade($this->em);
+        $perfil = TestHelper::createPerfil($this->em);
+        $usuario = TestHelper::getUser($this->em);
+
+        TestHelper::linkUnidadeUsuario($this->em, $unidade, $usuario, $perfil);
+        TestHelper::linkServicoUnidade($this->em, $servico, $unidade);
+
+        $data = [
+            'unidade' => $unidade->getId(),
+            'servico' => $servico->getId(),
+            'prioridade' => $prioridade->getId(),
+            'agendamento' => 0,
+        ];
+
+        $client->jsonRequest('POST', '/api/distribui', parameters: $data, server: [
+            'HTTP_AUTHORIZATION' => sprintf('Bearer %s', $accessToken),
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $response = $client->getResponse();
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertIsArray($result['error']);
+        $this->assertArrayHasKey('agendamento', $result['error']);
+    }
+
+    public function testDistribuiSenhaWithAgendamento(): void
+    {
+        $client = static::getClient();
+        $usuario = TestHelper::getUser($this->em);
+        $accessToken = TestHelper::generateJwtToken(static::getContainer());
+        $unidade = TestHelper::createUnidade($this->em);
+        $servico = TestHelper::createServico($this->em);
+        $prioridade = TestHelper::createPrioridade($this->em);
+        $perfil = TestHelper::createPerfil($this->em);
+        $cliente = TestHelper::createCliente($this->em);
+
+        TestHelper::linkUnidadeUsuario($this->em, $unidade, $usuario, $perfil);
+        $servicoUnidade = TestHelper::linkServicoUnidade($this->em, $servico, $unidade);
+
+        // schedule at 15:30, clock is at 15:20 (future appointment)
+        $agendamento = TestHelper::createAgendamento(
+            $this->em,
+            $cliente,
+            $unidade,
+            $servico,
+            new \DateTime('2026-03-29'),
+            new \DateTime('15:30'),
+        );
+
+        $data = [
+            'unidade' => $unidade->getId(),
+            'servico' => $servico->getId(),
+            'prioridade' => $prioridade->getId(),
+            'agendamento' => $agendamento->getId(),
+        ];
+
+        $client->jsonRequest('POST', '/api/distribui', parameters: $data, server: [
+            'HTTP_AUTHORIZATION' => sprintf('Bearer %s', $accessToken),
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $response = $client->getResponse();
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('id', $result);
+        $this->assertSame($result['status'], AtendimentoService::SENHA_EMITIDA);
+        $this->assertSame($result['senha']['sigla'], $servicoUnidade->getSigla());
+        $this->assertNotNull($result['dataAgendamento']);
+        $this->assertSame($result['cliente']['id'], $cliente->getId());
+    }
+
+    public function testDistribuiSenhaWithExpiredAgendamento(): void
+    {
+        $client = static::getClient();
+        $usuario = TestHelper::getUser($this->em);
+        $accessToken = TestHelper::generateJwtToken(static::getContainer());
+        $unidade = TestHelper::createUnidade($this->em);
+        $servico = TestHelper::createServico($this->em);
+        $prioridade = TestHelper::createPrioridade($this->em);
+        $perfil = TestHelper::createPerfil($this->em);
+        $cliente = TestHelper::createCliente($this->em);
+
+        TestHelper::linkUnidadeUsuario($this->em, $unidade, $usuario, $perfil);
+        TestHelper::linkServicoUnidade($this->em, $servico, $unidade);
+
+        // 13:00 is 140 mins before clock (15:20) — exceeds default 60 min delay
+        $agendamento = TestHelper::createAgendamento(
+            $this->em,
+            $cliente,
+            $unidade,
+            $servico,
+            new \DateTime('2026-03-29'),
+            new \DateTime('13:00'),
+        );
+
+        $data = [
+            'unidade' => $unidade->getId(),
+            'servico' => $servico->getId(),
+            'prioridade' => $prioridade->getId(),
+            'agendamento' => $agendamento->getId(),
+        ];
+
+        $client->jsonRequest('POST', '/api/distribui', parameters: $data, server: [
+            'HTTP_AUTHORIZATION' => sprintf('Bearer %s', $accessToken),
+        ]);
+
+        $this->assertResponseStatusCodeSame(422);
+        $response = $client->getResponse();
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertStringContainsString(
+            'Agendamento expirado. Tempo máximo de espera de 60 minutos.',
+            $result['error'],
+        );
     }
 
     public function testDistribuiSenhaWithDifferentTimezones(): void

--- a/tests/Service/AtendimentoServiceTest.php
+++ b/tests/Service/AtendimentoServiceTest.php
@@ -656,6 +656,7 @@ class AtendimentoServiceTest extends TestCase
 
         $agendamento = (new Agendamento())
             ->setUnidade($unidade)
+            ->setServico($servico)
             ->setData($this->clock->now())
             ->setHora($this->clock->now())
             ->setCliente(new Cliente());
@@ -704,6 +705,7 @@ class AtendimentoServiceTest extends TestCase
             ->modify("-" . self::CONFIGURED_DELAY . " minutes -2 minutes");
         $agendamento = (new Agendamento())
             ->setUnidade($unidade)
+            ->setServico($servico)
             ->setData($appointmentTime)
             ->setHora($appointmentTime)
             ->setCliente(new Cliente());
@@ -717,6 +719,64 @@ class AtendimentoServiceTest extends TestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('error.schedule.expired');
+
+        $this->service->distribuiSenha($unidade, $usuario, $servico, $prioridade, null, $agendamento);
+    }
+
+    public function testDistribuiSenhaWithAppointmentFromDifferentUnity(): void
+    {
+        $unidade = (new Unidade())->setId(1);
+        $outraUnidade = (new Unidade())->setId(2);
+        $usuario = (new Usuario())->setAdmin(true);
+        $servico = new Servico();
+        $prioridade = new Prioridade();
+
+        $agendamento = (new Agendamento())
+            ->setUnidade($outraUnidade)
+            ->setServico($servico)
+            ->setData($this->clock->now())
+            ->setHora($this->clock->now())
+            ->setCliente(new Cliente());
+
+        $this->translator->addResource('array', [
+            'error.schedule.invalid_unity' => 'O agendamento não pertence à unidade selecionada.',
+        ], self::TEST_LOCALE);
+
+        /** @var EntityManagerInterface&MockObject */
+        $em = $this->createMock(EntityManagerInterface::class);
+        $this->storage->method('getManager')->willReturn($em);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('O agendamento não pertence à unidade selecionada.');
+
+        $this->service->distribuiSenha($unidade, $usuario, $servico, $prioridade, null, $agendamento);
+    }
+
+    public function testDistribuiSenhaWithAppointmentFromDifferentService(): void
+    {
+        $unidade = (new Unidade())->setId(1);
+        $servico = (new Servico())->setId(1);
+        $outroServico = (new Servico())->setId(2);
+        $usuario = (new Usuario())->setAdmin(true);
+        $prioridade = new Prioridade();
+
+        $agendamento = (new Agendamento())
+            ->setUnidade($unidade)
+            ->setServico($outroServico)
+            ->setData($this->clock->now())
+            ->setHora($this->clock->now())
+            ->setCliente(new Cliente());
+
+        $this->translator->addResource('array', [
+            'error.schedule.invalid_service' => 'O agendamento não pertence ao serviço selecionado.',
+        ], self::TEST_LOCALE);
+
+        /** @var EntityManagerInterface&MockObject */
+        $em = $this->createMock(EntityManagerInterface::class);
+        $this->storage->method('getManager')->willReturn($em);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('O agendamento não pertence ao serviço selecionado.');
 
         $this->service->distribuiSenha($unidade, $usuario, $servico, $prioridade, null, $agendamento);
     }

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -814,6 +814,14 @@
                 <source>error.schedule.invalid_datetime</source>
                 <target>Invalid appointment date/time.</target>
             </trans-unit>
+            <trans-unit id="error.schedule.invalid_unity">
+                <source>error.schedule.invalid_unity</source>
+                <target>Appointment does not belong to the selected unit.</target>
+            </trans-unit>
+            <trans-unit id="error.schedule.invalid_service">
+                <source>error.schedule.invalid_service</source>
+                <target>Appointment does not belong to the selected service.</target>
+            </trans-unit>
             <trans-unit id="label.color">
                 <source>label.color</source>
                 <target>Color</target>

--- a/translations/messages.en_US.xlf
+++ b/translations/messages.en_US.xlf
@@ -814,6 +814,14 @@
                 <source>error.schedule.invalid_datetime</source>
                 <target>Invalid appointment date/time.</target>
             </trans-unit>
+            <trans-unit id="error.schedule.invalid_unity">
+                <source>error.schedule.invalid_unity</source>
+                <target>Appointment does not belong to the selected unit.</target>
+            </trans-unit>
+            <trans-unit id="error.schedule.invalid_service">
+                <source>error.schedule.invalid_service</source>
+                <target>Appointment does not belong to the selected service.</target>
+            </trans-unit>
             <trans-unit id="label.color">
                 <source>label.color</source>
                 <target>Color</target>

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -814,6 +814,14 @@
                 <source>error.schedule.invalid_datetime</source>
                 <target>Fecha/hora de turno inválida.</target>
             </trans-unit>
+            <trans-unit id="error.schedule.invalid_unity">
+                <source>error.schedule.invalid_unity</source>
+                <target>El turno no pertenece a la unidad seleccionada.</target>
+            </trans-unit>
+            <trans-unit id="error.schedule.invalid_service">
+                <source>error.schedule.invalid_service</source>
+                <target>El turno no pertenece al servicio seleccionado.</target>
+            </trans-unit>
             <trans-unit id="label.color">
                 <source>label.color</source>
                 <target>Cor</target>

--- a/translations/messages.es_AR.xlf
+++ b/translations/messages.es_AR.xlf
@@ -814,6 +814,14 @@
                 <source>error.schedule.invalid_datetime</source>
                 <target>Fecha/hora de turno inválida.</target>
             </trans-unit>
+            <trans-unit id="error.schedule.invalid_unity">
+                <source>error.schedule.invalid_unity</source>
+                <target>El turno no pertenece a la unidad seleccionada.</target>
+            </trans-unit>
+            <trans-unit id="error.schedule.invalid_service">
+                <source>error.schedule.invalid_service</source>
+                <target>El turno no pertenece al servicio seleccionado.</target>
+            </trans-unit>
             <trans-unit id="label.color">
                 <source>label.color</source>
                 <target>Cor</target>

--- a/translations/messages.pt_BR.xlf
+++ b/translations/messages.pt_BR.xlf
@@ -810,6 +810,14 @@
                 <source>error.schedule.invalid_datetime</source>
                 <target>Data/hora do agendamento inválida.</target>
             </trans-unit>
+            <trans-unit id="error.schedule.invalid_unity">
+                <source>error.schedule.invalid_unity</source>
+                <target>O agendamento não pertence à unidade selecionada.</target>
+            </trans-unit>
+            <trans-unit id="error.schedule.invalid_service">
+                <source>error.schedule.invalid_service</source>
+                <target>O agendamento não pertence ao serviço selecionado.</target>
+            </trans-unit>
             <trans-unit id="label.color">
                 <source>label.color</source>
                 <target>Cor</target>

--- a/translations/messages.pt_PT.xlf
+++ b/translations/messages.pt_PT.xlf
@@ -814,6 +814,14 @@
                 <source>error.schedule.invalid_datetime</source>
                 <target>Data/hora do agendamento inválida.</target>
             </trans-unit>
+            <trans-unit id="error.schedule.invalid_unity">
+                <source>error.schedule.invalid_unity</source>
+                <target>O agendamento não pertence à unidade selecionada.</target>
+            </trans-unit>
+            <trans-unit id="error.schedule.invalid_service">
+                <source>error.schedule.invalid_service</source>
+                <target>O agendamento não pertence ao serviço selecionado.</target>
+            </trans-unit>
             <trans-unit id="label.color">
                 <source>label.color</source>
                 <target>Cor</target>


### PR DESCRIPTION
Fixes https://github.com/novosga/novosga/issues/478

This pull request adds support for handling appointment (`agendamento`) data when distributing tickets (`senha`) in the triage API. It introduces new logic in the controller and DTO to accept and validate appointment IDs, and provides comprehensive tests covering various scenarios including valid, invalid, and expired appointments.

**API Enhancements:**

* The `distribui` endpoint in `TriagemController` now accepts an optional `agendamento` parameter, retrieves the corresponding appointment using `AgendamentoRepositoryInterface`, and passes it to the service layer. [[1]](diffhunk://#diff-0e91206652f8c3209d05f3fa5703157bfbaae1790839e8a5df8cec9e995d1095R22) [[2]](diffhunk://#diff-0e91206652f8c3209d05f3fa5703157bfbaae1790839e8a5df8cec9e995d1095R62) [[3]](diffhunk://#diff-0e91206652f8c3209d05f3fa5703157bfbaae1790839e8a5df8cec9e995d1095R76-L75)
* The `NovaSenha` DTO is updated to include an optional `agendamento` field with validation to ensure it is a positive integer.

**Testing Improvements:**

* Added tests for the new appointment logic, including:
  - Submitting a valid appointment (`agendamento`) and checking correct processing.
  - Submitting an invalid appointment ID and expecting a validation error.
  - Submitting an expired appointment and expecting an error about the maximum wait time.
  - Ensuring the response correctly reflects the appointment data when present or absent.