### PR TITLE
fix: variable variable typo breaks redirect to a specific atendente

### DIFF
--- a/src/Service/AtendimentoService.php
+++ b/src/Service/AtendimentoService.php
@@ -663,10 +663,10 @@ class AtendimentoService implements AtendimentoServiceInterface
         }
 
         if (is_int($novoAtendente)) {
-            $$novoAtendente = $this
+            $novoAtendente = $this
                 ->storage
                 ->getRepository(Usuario::class)
-                ->find($$novoAtendente);
+                ->find($novoAtendente);
         }
 
         $this->dispatcher->dispatch(new PreTicketRedirectEvent(


### PR DESCRIPTION
## Bug

`AtendimentoService::redirecionar()` has a typo: a variable variable (`$$novoAtendente`) instead of `$novoAtendente` when resolving the target atendente's `int` id into a `Usuario` entity:

```php
if (is_int($novoAtendente)) {
    $$novoAtendente = $this
        ->storage
        ->getRepository(Usuario::class)
        ->find($$novoAtendente);
}
```

Because of the extra `$`, `$novoAtendente` is never reassigned to the resolved `Usuario` entity — it's still the raw `int`, which then gets passed straight into `copyToRedirect()` and assigned via `setUsuario()`. In practice, this throws:

```
The identifier id is missing for a query of App\Entity\Usuario
```

This happens every time a ticket is redirected to a specific atendente (the `usuario` parameter of the `/redirecionar` route in the attendance bundle).

## Fix

Remove the extra `$`:

```php
if (is_int($novoAtendente)) {
    $novoAtendente = $this
        ->storage
        ->getRepository(Usuario::class)
        ->find($novoAtendente);
}
```

## Testing

Reproduced the error on a clean v2.3-standalone install, then verified the fix by calling `redirecionar()` directly with an `int` atendente id — before the fix it throws the error above, after the fix it resolves correctly and the new ticket is assigned to the target atendente.
