### PR TITLE
fix: adding an already-existing servico+unidade throws identity map error

### DIFF
--- a/src/Service/UnidadeService.php
+++ b/src/Service/UnidadeService.php
@@ -62,17 +62,26 @@ class UnidadeService implements UnidadeServiceInterface
         UnidadeInterface $unidade,
         string $sigla
     ): ServicoUnidadeInterface {
-        $su = new ServicoUnidade();
-        $su
-            ->setUnidade($unidade)
-            ->setServico($servico)
-            ->setIncremento(1)
-            ->setMensagem('')
-            ->setNumeroInicial(1)
-            ->setPeso(1)
-            ->setTipo(ServicoUnidadeInterface::ATENDIMENTO_TODOS)
-            ->setSigla($sigla)
-            ->setAtivo(false);
+        $su = $this->em->getRepository(ServicoUnidade::class)->findOneBy([
+            'unidade' => $unidade,
+            'servico' => $servico,
+        ]);
+
+        if ($su) {
+            $su->setSigla($sigla);
+        } else {
+            $su = new ServicoUnidade();
+            $su
+                ->setUnidade($unidade)
+                ->setServico($servico)
+                ->setIncremento(1)
+                ->setMensagem('')
+                ->setNumeroInicial(1)
+                ->setPeso(1)
+                ->setTipo(ServicoUnidadeInterface::ATENDIMENTO_TODOS)
+                ->setSigla($sigla)
+                ->setAtivo(false);
+        }
 
         $contador = $this->contadorRepository->findOneBy([
             'unidade' => $unidade,


### PR DESCRIPTION
## Bug

`UnidadeService::addServicoUnidade()` always creates a brand new `ServicoUnidade` and persists it, without checking whether one already exists for that `servico`+`unidade` pair (`ServicoUnidade` uses a composite primary key of `servico_id`+`unidade_id`):

```php
$su = new ServicoUnidade();
$su
    ->setUnidade($unidade)
    ->setServico($servico)
    ...
$this->em->persist($su);
$this->em->flush();
```

If a row already exists for that pair, persisting a new instance collides in Doctrine's identity map before it even reaches the database:

```
While adding an entity of class App\Entity\ServicoUnidade with an ID hash of "X Y" to the identity map,
another object of class App\Entity\ServicoUnidade was already present for the same ID.
```

Since the call never completes, the servico never actually ends up linked/active for that unidade — which also makes it disappear from the list of servicos available in Triagem for issuing tickets.

## Fix

Look up the existing `ServicoUnidade` first; if found, just update the `sigla` instead of trying to create a duplicate.

## Testing

Called `addServicoUnidade()` twice in a row for the same servico+unidade pair (simulating a resend/double click). Before the fix, the second call throws the identity map error above. After the fix, both calls succeed, the sigla gets updated, and only one row exists in the database for that pair.
