### PR TITLE
Fix: fresh install can crash with "SAVEPOINT DOCTRINE_N does not exist"

### DIFF
--- a/migrations/Version1.php
+++ b/migrations/Version1.php
@@ -26,6 +26,20 @@ final class Version1 extends AbstractMigration
         return 'Init';
     }
 
+    public function isTransactional(): bool
+    {
+        // This migration executes a large raw SQL dump full of
+        // CREATE TABLE/ALTER TABLE statements, which cause an implicit
+        // commit on MySQL. Wrapping it in a Doctrine transaction/savepoint
+        // just desyncs the connection's transaction nesting counter from
+        // what the database actually did, which then breaks whatever runs
+        // next on the same connection within the same process (e.g. the
+        // "novosga:install" command creating the admin user right after
+        // running migrations, failing with "SAVEPOINT DOCTRINE_N does not
+        // exist").
+        return false;
+    }
+
     public function up(Schema $schema) : void
     {
         if ($this->platform instanceof MySQLPlatform) {

--- a/migrations/Version2.php
+++ b/migrations/Version2.php
@@ -23,6 +23,13 @@ final class Version2 extends AbstractMigration
         return 'Local vs Atendimento relationship';
     }
 
+    public function isTransactional(): bool
+    {
+        // ALTER TABLE / DROP VIEW / CREATE VIEW all cause an implicit
+        // commit on MySQL. Same reasoning as Version1::isTransactional().
+        return false;
+    }
+
     public function up(Schema $schema) : void
     {
         if (!$schema->getTable('atendimentos')->hasColumn('local_id')) {

--- a/migrations/Version20210326134543.php
+++ b/migrations/Version20210326134543.php
@@ -26,6 +26,13 @@ final class Version20210326134543 extends AbstractMigration
         return 'Improviments';
     }
 
+    public function isTransactional(): bool
+    {
+        // ALTER TABLE / CREATE INDEX cause an implicit commit on MySQL.
+        // Same reasoning as Version1::isTransactional().
+        return false;
+    }
+
     public function up(Schema $schema) : void
     {
         $isMySQL = $this->platform instanceof MySQLPlatform;

--- a/migrations/Version20240723214655.php
+++ b/migrations/Version20240723214655.php
@@ -26,6 +26,14 @@ final class Version20240723214655 extends AbstractMigration
         return 'OAuth Server migration';
     }
 
+    public function isTransactional(): bool
+    {
+        // Loads a raw SQL file plus DROP TABLE statements, both of which
+        // cause an implicit commit on MySQL. Same reasoning as
+        // Version1::isTransactional().
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($this->platform instanceof MySQLPlatform) {

--- a/migrations/Version20241223212116.php
+++ b/migrations/Version20241223212116.php
@@ -26,6 +26,14 @@ final class Version20241223212116 extends AbstractMigration
         return 'Webhook support';
     }
 
+    public function isTransactional(): bool
+    {
+        // Loads a raw SQL file containing CREATE TABLE statements, which
+        // cause an implicit commit on MySQL. Same reasoning as
+        // Version1::isTransactional().
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($this->platform instanceof MySQLPlatform) {

--- a/migrations/Version20260213170231.php
+++ b/migrations/Version20260213170231.php
@@ -23,6 +23,13 @@ final class Version20260213170231 extends AbstractMigration
         return 'Add timezone field to unidades table';
     }
 
+    public function isTransactional(): bool
+    {
+        // ALTER TABLE causes an implicit commit on MySQL. Same reasoning
+        // as Version1::isTransactional().
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         $this->addSql('ALTER TABLE unidades ADD timezone VARCHAR(50) DEFAULT NULL');

--- a/migrations/Version20260408103746.php
+++ b/migrations/Version20260408103746.php
@@ -29,6 +29,14 @@ final class Version20260408103746 extends AbstractMigration
         return 'Builtin Painel';
     }
 
+    public function isTransactional(): bool
+    {
+        // Loads a raw SQL file containing CREATE TABLE statements, which
+        // cause an implicit commit on MySQL. Same reasoning as
+        // Version1::isTransactional().
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if ($this->platform instanceof MySQLPlatform) {

--- a/migrations/Version20260424000000.php
+++ b/migrations/Version20260424000000.php
@@ -26,6 +26,13 @@ final class Version20260424000000 extends AbstractMigration
         return 'Adds cor_prioridade column to painel_senha table';
     }
 
+    public function isTransactional(): bool
+    {
+        // ALTER TABLE causes an implicit commit on MySQL. Same reasoning
+        // as Version1::isTransactional().
+        return false;
+    }
+
     public function up(Schema $schema): void
     {
         if (!$schema->getTable('painel_senha')->hasColumn('cor_prioridade')) {


### PR DESCRIPTION
## Bug

On a brand new database, `novosga:install` can crash right after migrations run, while creating the admin user:

```
SQLSTATE[42000]: Syntax error or access violation: 1305 SAVEPOINT DOCTRINE_N does not exist
```

**Root cause:** 8 migrations execute DDL (`CREATE TABLE`/`ALTER TABLE`/`DROP TABLE`/`CREATE VIEW`/`DROP VIEW`, either inline or via a loaded raw `.sql` file) without overriding `AbstractMigration::isTransactional()` to `false`. DDL causes an implicit commit on MySQL — something Doctrine Migrations itself already flags as deprecated:

> User Deprecated: Context: trying to commit a transaction. Problem: the transaction is already committed, relying on silencing is deprecated. Solution: override `AbstractMigration::isTransactional()` so that it returns false.
> https://github.com/doctrine/migrations/issues/1169

Since `novosga:install` runs migrations and creates the admin user in the same process/connection, the implicit commit desyncs the connection's transaction/savepoint nesting counter for the rest of the install. The very next wrapped transaction (admin user creation) then fails trying to release/rollback a savepoint that MySQL had already implicitly closed.

Because the container typically runs with `restart: unless-stopped`, this tends to silently "fix itself" on the automatic restart (migrations are already applied, only admin-user creation gets retried on a clean connection) — so it's easy to miss in day-to-day use, but it does make a truly fresh install crash and restart at least once.

## Fix

Override `isTransactional(): false` on the 8 affected migrations:
`Version1`, `Version2`, `Version20210326134543`, `Version20240723214655`, `Version20241223212116`, `Version20260213170231`, `Version20260408103746`, `Version20260424000000`.

## Testing

- Reproduced the crash consistently on a clean MySQL 8.0.46 + fresh install (same `SAVEPOINT DOCTRINE_N` error every time).
- Ran `doctrine:migrations:migrate --no-interaction -vvv` before/after: before the fix, several migrations log the implicit-commit deprecation; after the fix, none do.
- Ran a full fresh `novosga:install` (default container entrypoint, no manual retry) after the fix: completes successfully on the first attempt.
